### PR TITLE
Enable etcd HA on virtual Kubernetes clusters

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -76,8 +76,6 @@ spec:
       value: 4Gi
     - name: controlPlane.hostPathMapper.enabled
       value: 'true'
-    - name: controlPlane.backingStore.database.embedded.enabled
-      value: 'true'
     - name: controlPlane.statefulSet.persistence.volumeClaim.retentionPolicy
       value: Delete
     - name: controlPlane.statefulSet.persistence.volumeClaim.size

--- a/pkg/provisioners/helmapplications/virtualcluster/provisioner.go
+++ b/pkg/provisioners/helmapplications/virtualcluster/provisioner.go
@@ -104,14 +104,15 @@ func (p *Provisioner) Values(ctx context.Context, version unikornv1core.Semantic
 		},
 	}
 
-	// Choose the database options... wisely.
-	// TODO: etcd is only available with a Pro license, we can probably source this from
-	// some controller options pointing at a secret and adapt the configuration based on
-	// its presence.
 	backingStore := map[string]any{
-		"database": map[string]any{
-			"embedded": map[string]any{
+		"etcd": map[string]any{
+			"deploy": map[string]any{
 				"enabled": true,
+				"statefulSet": map[string]any{
+					"highAvailability": map[string]int{
+						"replicas": 3,
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Enable HA etcd by default for virtual Kubernetes clusters.

Remove the 'embedded' option from the default application, since that is unused - Pro-only feature - and the Helm templating validation complains if you try to mix.