### PR TITLE
Remove Deadcode

### DIFF
--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -86,9 +86,6 @@ type Client struct {
 	// client allows Kubernetes API access.
 	client client.Client
 
-	// namespace the controller runs in.
-	namespace string
-
 	// options control various defaults and the like.
 	options *Options
 
@@ -100,13 +97,12 @@ type Client struct {
 }
 
 // NewClient returns a new client with required parameters.
-func NewClient(client client.Client, namespace string, options *Options, identity *identity.Client, region *region.Client) *Client {
+func NewClient(client client.Client, options *Options, identity *identity.Client, region *region.Client) *Client {
 	return &Client{
-		client:    client,
-		namespace: namespace,
-		options:   options,
-		identity:  identity,
-		region:    region,
+		client:   client,
+		options:  options,
+		identity: identity,
+		region:   region,
 	}
 }
 

--- a/pkg/server/handler/handler.go
+++ b/pkg/server/handler/handler.go
@@ -257,7 +257,7 @@ func (h *Handler) PutApiV1OrganizationsOrganizationIDProjectsProjectIDClusterman
 }
 
 func (h *Handler) clusterClient() *cluster.Client {
-	return cluster.NewClient(h.client, h.namespace, &h.options.Cluster, h.identity, h.region)
+	return cluster.NewClient(h.client, &h.options.Cluster, h.identity, h.region)
 }
 
 func (h *Handler) GetApiV1OrganizationsOrganizationIDClusters(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter) {
@@ -362,7 +362,7 @@ func (h *Handler) GetApiV1OrganizationsOrganizationIDProjectsProjectIDClustersCl
 }
 
 func (h *Handler) virtualClusterClient() *virtualcluster.Client {
-	return virtualcluster.NewClient(h.client, h.namespace, h.identity, h.region)
+	return virtualcluster.NewClient(h.client, h.identity, h.region)
 }
 
 func (h *Handler) GetApiV1OrganizationsOrganizationIDVirtualclusters(w http.ResponseWriter, r *http.Request, organizationID openapi.OrganizationIDParameter) {

--- a/pkg/server/handler/virtualcluster/client.go
+++ b/pkg/server/handler/virtualcluster/client.go
@@ -58,9 +58,6 @@ type Client struct {
 	// client allows Kubernetes API access.
 	client client.Client
 
-	// namespace the controller runs in.
-	namespace string
-
 	// identity is a client to access the identity service.
 	identity *identity.Client
 
@@ -69,12 +66,11 @@ type Client struct {
 }
 
 // NewClient returns a new client with required parameters.
-func NewClient(client client.Client, namespace string, identity *identity.Client, region *region.Client) *Client {
+func NewClient(client client.Client, identity *identity.Client, region *region.Client) *Client {
 	return &Client{
-		client:    client,
-		namespace: namespace,
-		identity:  identity,
-		region:    region,
+		client:   client,
+		identity: identity,
+		region:   region,
 	}
 }
 


### PR DESCRIPTION
From a previous review I noted a bunch of dead code (propagating namespaces) was leading me into a dead end, so remove them as they are unused.  Any accesses to clusters/cluster managers are relative to the resource itself and not where the service is deployed.