### PR TITLE
Bump chart version for v1.3.1

### DIFF
--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn Kubernetes Service
 
 type: application
 
-version: v1.3.0
-appVersion: v1.3.0
+version: v1.3.1
+appVersion: v1.3.1
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
The chart is the only place the version needs changing -- no dependencies have changed. Since this is a patch version, I haven't bothered bumping the version in the OpenAPI either.