### PR TITLE
Enable Gateway API

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -202,6 +202,23 @@ spec:
       value: 'false'
     - name: bpf.lbExternalClusterIP
       value: 'true'
+  - version: 1.18.0-pre.3
+    repo: https://helm.cilium.io
+    chart: cilium
+    namespace: kube-system
+    parameters:
+    - name: hubble.relay.enabled
+      value: 'true'
+    - name: hubble.ui.enabled
+      value: 'true'
+    - name: operator.setNodeTaints
+      value: 'false'
+    - name: envoy.enabled
+      value: 'false'
+    - name: bpf.lbExternalClusterIP
+      value: 'true'
+    - name: gatewayAPI.enabled
+      value: 'true'
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication
@@ -483,3 +500,23 @@ spec:
   - version: v0.1.0
     repo: https://nscaledev.github.io/uni-helm-cluster-api
     chart: cluster-api-cluster-autoscaler-openstack
+---
+apiVersion: unikorn-cloud.org/v1alpha1
+kind: HelmApplication
+metadata:
+  name: {{ include "resource.id" "gateway-api-crds" }}
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+    unikorn-cloud.org/name: gateway-api-crds
+  annotations:
+    unikorn-cloud.org/description: |-
+      Gateway API CRDs
+spec:
+  icon: []
+  documentation: https://gateway-api.sigs.k8s.io/
+  license: Apache-2.0 License
+  versions:
+  - version: v1.3.0
+    repo: https://github.com/kubernetes-sigs/gateway-api
+    path: config/crd
+    branch: v1.3.0

--- a/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/kubernetesclusterapplicationbundles.yaml
@@ -297,3 +297,68 @@ spec:
       kind: HelmApplication
       name: {{ include "resource.id" "cluster-autoscaler-openstack" }}
       version: v0.1.0
+---
+apiVersion: unikorn-cloud.org/v1alpha1
+kind: KubernetesClusterApplicationBundle
+metadata:
+  name: kubernetes-cluster-1.3.0
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  version: 1.3.0
+  applications:
+  - name: cluster-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-openstack" }}
+      version: v0.6.1
+  - name: cilium
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cilium" }}
+      version: 1.18.0-pre.3
+  - name: openstack-cloud-provider
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-cloud-provider" }}
+      version: 2.32.0
+  - name: openstack-plugin-cinder-csi
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "openstack-plugin-cinder-csi" }}
+      version: 2.32.0
+  - name: metrics-server
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "metrics-server" }}
+      version: 3.12.2
+  - name: nvidia-gpu-operator
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "nvidia-gpu-operator" }}
+      version: v25.3.0
+  - name: cert-manager
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cert-manager" }}
+      version: v1.17.1
+  - name: amd-gpu-operator
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "amd-gpu-operator" }}
+      version: v1.2.0
+  - name: cluster-autoscaler
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler" }}
+      version: 9.29.3
+  - name: cluster-autoscaler-openstack
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "cluster-autoscaler-openstack" }}
+      version: v0.1.0
+  - name: gateway-api-crds
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "gateway-api-crds" }}
+      version: v1.3.0

--- a/pkg/provisioners/helmapplications/gatewayapi/provisioner.go
+++ b/pkg/provisioners/helmapplications/gatewayapi/provisioner.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2022-2024 EscherCloud.
+Copyright 2024-2025 the Unikorn Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Deploy the Gateway API CRDs
+package gatewayapi
+
+import (
+	"github.com/unikorn-cloud/core/pkg/provisioners/application"
+)
+
+// New returns a new initialized provisioner object.
+func New(getApplication application.GetterFunc) *application.Provisioner {
+	return application.New(getApplication)
+}

--- a/pkg/provisioners/managers/cluster/provisioner.go
+++ b/pkg/provisioners/managers/cluster/provisioner.go
@@ -49,6 +49,7 @@ import (
 	"github.com/unikorn-cloud/kubernetes/pkg/provisioners/helmapplications/clusterautoscaler"
 	"github.com/unikorn-cloud/kubernetes/pkg/provisioners/helmapplications/clusterautoscaleropenstack"
 	"github.com/unikorn-cloud/kubernetes/pkg/provisioners/helmapplications/clusteropenstack"
+	"github.com/unikorn-cloud/kubernetes/pkg/provisioners/helmapplications/gatewayapi"
 	"github.com/unikorn-cloud/kubernetes/pkg/provisioners/helmapplications/metricsserver"
 	"github.com/unikorn-cloud/kubernetes/pkg/provisioners/helmapplications/nvidiagpuoperator"
 	"github.com/unikorn-cloud/kubernetes/pkg/provisioners/helmapplications/openstackcloudprovider"
@@ -155,6 +156,10 @@ func (a *ApplicationReferenceGetter) clusterAutoscaler(ctx context.Context) (*un
 
 func (a *ApplicationReferenceGetter) clusterAutoscalerOpenstack(ctx context.Context) (*unikornv1core.HelmApplication, *unikornv1core.SemanticVersion, error) {
 	return a.getApplication(ctx, "cluster-autoscaler-openstack")
+}
+
+func (a *ApplicationReferenceGetter) gatewayAPI(ctx context.Context) (*unikornv1core.HelmApplication, *unikornv1core.SemanticVersion, error) {
+	return a.getApplication(ctx, "gateway-api-crds")
 }
 
 // Options allows access to CLI options in the provisioner.
@@ -323,6 +328,7 @@ func (p *Provisioner) getProvisioner(ctx context.Context, options *kubernetespro
 	addonsProvisioner := concurrent.New("cluster add-ons",
 		openstackplugincindercsi.New(apps.openstackPluginCinderCSI, options),
 		metricsserver.New(apps.metricsServer),
+		gatewayapi.New(apps.gatewayAPI),
 		conditional.New("nvidia-gpu-operator",
 			func() bool { return p.cluster.GPUOperatorEnabled() && provisionerOptions.gpuVendorNvidia },
 			nvidiagpuoperator.New(apps.nvidiaGPUOperator),


### PR DESCRIPTION
Flip the switch on Cilium to enable Gateway API, and add a new application which deploys the CRDs since these are not included with the CNI.

Upgrades Cilium to the latest while we're at it, all defined in a new version of the bundle.