### PR TITLE
Propagate VKC labels to the remote vcluster namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
-	github.com/unikorn-cloud/core v1.3.0
+	github.com/unikorn-cloud/core v1.3.1-rc1
 	github.com/unikorn-cloud/identity v1.3.0
 	github.com/unikorn-cloud/region v1.3.0
 	go.opentelemetry.io/otel v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/unikorn-cloud/core v1.3.0 h1:K5NuSAspBU2ud6c+bYQ5Tc6+5VMReZsTQmJBZlEbs+4=
 github.com/unikorn-cloud/core v1.3.0/go.mod h1:w+knncdBlLfVg82Ky3BejohUqiXrCUPFnAup1yZYbyM=
+github.com/unikorn-cloud/core v1.3.1-rc1 h1:UCWtHD420KmnyrgRMyNQMhhqqIVLqB+PaFcpsiLnBRE=
+github.com/unikorn-cloud/core v1.3.1-rc1/go.mod h1:w+knncdBlLfVg82Ky3BejohUqiXrCUPFnAup1yZYbyM=
 github.com/unikorn-cloud/identity v1.3.0 h1:3x/Ey70e2UlUyya2JxvcS3G7EJCGKFBbEiJ0cPgpuzI=
 github.com/unikorn-cloud/identity v1.3.0/go.mod h1:laE9JrAzUxMDnqwOINo+h33Ra7ihk5zm070HbvsnS/0=
 github.com/unikorn-cloud/region v1.3.0 h1:AlewC7hZbS162UqdDxF59Oh5jWa6z6G3XsccsbPXHyU=

--- a/pkg/provisioners/helmapplications/virtualcluster/provisioner.go
+++ b/pkg/provisioners/helmapplications/virtualcluster/provisioner.go
@@ -54,6 +54,20 @@ func init() {
 	metrics.Registry.MustRegister(durationMetric)
 }
 
+type labelPropagator struct {
+}
+
+func (p labelPropagator) NamespaceMetadata(ctx context.Context, _ unikornv1core.SemanticVersion) (map[string]string, map[string]string, error) {
+	origin := application.FromContext(ctx)
+
+	originLabels, err := origin.ResourceLabels() // this gives us the org, project, kind and name.
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return originLabels, nil, nil
+}
+
 type ProvisionerOptions struct {
 	Domain            string
 	NodeSelectorLabel string
@@ -86,7 +100,8 @@ func (opts *ProvisionerOptions) NodeSelector(vclusterName string) map[string]str
 }
 
 type Provisioner struct {
-	Options ProvisionerOptions
+	labelPropagator // get the implementation of NamespaceMetadata from here
+	Options         ProvisionerOptions
 }
 
 // New returns a new initialized provisioner object.


### PR DESCRIPTION
This uses the facility in uni-core v1.3.1(-rc) for providing metadata for the CD driver-created namespace, to propagate a VirtualKubernetesCluster's own labels to the namespace created for a virtual cluster.

This gives a clear link between that namespace and the VKC in the managing cluster, as well as a nice hook for selecting namespaces that represent virtual clusters:

    kubectl get node -l unikorn-cloud.org/kind=virtualkubernetescluster

How this works:

 - the packages in pkg/provisioners/helmapplications/ are used to assemble HelmApplications, by implementing generator callbacks to e.g., supply values for the Helm chart that'll be used.
 - in helmapplications/virtualcluster, the generator so supplied implements `.NamespaceMetadata(...)`, which (after https://github.com/nscaledev/uni-core/pull/149, included in uni-core 1.3.1-rc1) results in an ArgoCD Application to sync the chart with `.managedNamespaceMetadata` including the labels.
 - the labels returned by `NamespaceMetadata(...)` are those that identify the VirtualKubernetesCluster.
