### PR TITLE
Fix VCluster Updates

### DIFF
--- a/pkg/server/handler/virtualcluster/client.go
+++ b/pkg/server/handler/virtualcluster/client.go
@@ -418,7 +418,7 @@ func (c *Client) Update(ctx context.Context, appclient appBundleLister, organiza
 		return err
 	}
 
-	if err := conversion.UpdateObjectMetadata(required, current, []string{constants.IdentityAnnotation}, []string{constants.PhysicalNetworkAnnotation}); err != nil {
+	if err := conversion.UpdateObjectMetadata(required, current, nil, nil); err != nil {
 		return errors.OAuth2ServerError("failed to merge metadata").WithError(err)
 	}
 


### PR DESCRIPTION
Copy and paste fail from the stadard clusters that require an identity and optional network, these don't exist for virtual clusters.

Additionally I discovered someone made a breaking change, requiring an application unconditionally when it's only supported from v1.3.0 onward, thus breaking any existing clusters.