### PR TITLE
Add kind label requirement to project selector in common handler

### DIFF
--- a/pkg/server/handler/common/common.go
+++ b/pkg/server/handler/common/common.go
@@ -57,8 +57,13 @@ func (c *Client) ProjectNamespace(ctx context.Context, organization, project str
 		return nil, err
 	}
 
+	kindRequirement, err := labels.NewRequirement(constants.KindLabel, selection.Equals, []string{constants.KindLabelValueProject})
+	if err != nil {
+		return nil, err
+	}
+
 	selector := labels.NewSelector()
-	selector = selector.Add(*organizationRequirement, *projectRequirement)
+	selector = selector.Add(*organizationRequirement, *projectRequirement, *kindRequirement)
 
 	options := &client.ListOptions{
 		LabelSelector: selector,


### PR DESCRIPTION
This PR introduces a new requirement for the project namespace selector to fix a conflict with namespaces created by SOS. 

The SOS API and controller are deployed on the same Kubernetes cluster, and SOS creates namespaces for Slinky clusters with identical labeling to the Kubernetes service. This causes a conflict during namespace reading. Adding the kind label requirement ensures proper differentiation and prevents this issue.

The same logic is already available on the compute service: https://github.com/nscaledev/uni-compute/blob/main/pkg/server/handler/common/common.go#L60