### PR TITLE
New VKC bundle, enable ImageVolume feature gate

### DIFF
--- a/charts/kubernetes/templates/applications.yaml
+++ b/charts/kubernetes/templates/applications.yaml
@@ -111,6 +111,18 @@ spec:
       value: 4Gi
     - name: vcluster.controlPlane.hostPathMapper.enabled
       value: 'true'
+  - version: 0.2.0
+    repo: https://github.com/nscaledev/uni-helm-virtualcluster
+    branch: v0.2.0
+    path: charts/virtualcluster
+    createNamespace: true
+    parameters:
+    - name: vcluster.controlPlane.statefulSet.resources.limits.memory
+      value: 4Gi
+    - name: vcluster.controlPlane.hostPathMapper.enabled
+      value: 'true'
+    - name: vcluster.controlPlane.distro.k8s.apiServer.extraArgs[0]
+      value: '--feature-gates=ImageVolume=true'
 ---
 apiVersion: unikorn-cloud.org/v1alpha1
 kind: HelmApplication

--- a/charts/kubernetes/templates/virtualkubernetesclusterapplicationbundles.yaml
+++ b/charts/kubernetes/templates/virtualkubernetesclusterapplicationbundles.yaml
@@ -12,3 +12,18 @@ spec:
       kind: HelmApplication
       name: {{ include "resource.id" "virtualcluster" }}
       version: 0.0.1
+---
+apiVersion: unikorn-cloud.org/v1alpha1
+kind: VirtualKubernetesClusterApplicationBundle
+metadata:
+  name: virtual-kubernetes-cluster-1.2.0
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+spec:
+  version: 1.2.0
+  applications:
+  - name: virtualcluster
+    reference:
+      kind: HelmApplication
+      name: {{ include "resource.id" "virtualcluster" }}
+      version: 0.2.0


### PR DESCRIPTION
As required by other services, introduce a new version of vCluster via our Helm chart and also pass through the ImageVolume feature gate enablement.