### PR TITLE
Use Kubernetes Native Cascading Deletion

### DIFF
--- a/charts/kubernetes/templates/cluster-manager-controller/clusterrole.yaml
+++ b/charts/kubernetes/templates/cluster-manager-controller/clusterrole.yaml
@@ -34,15 +34,15 @@ rules:
   - delete
   - update
 # Manage clusters (cascading deletion).
+# TODO: redundant after v1.8.0.
 - apiGroups:
   - unikorn-cloud.org
   resources:
   - kubernetesclusters
   verbs:
   - list
-  - get
   - watch
-  - delete
+  - update
 # Get application bundles
 - apiGroups:
   - unikorn-cloud.org

--- a/pkg/server/handler/cluster/conversion_test.go
+++ b/pkg/server/handler/cluster/conversion_test.go
@@ -180,6 +180,14 @@ func clusterRequestFixture(version string) *openapi.KubernetesClusterWrite {
 	}
 }
 
+func clusterManagerFixture() *unikornv1.ClusterManager {
+	return &unikornv1.ClusterManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-manager",
+		},
+	}
+}
+
 func existingClusterFixture(t *testing.T, version string) *unikornv1.KubernetesCluster {
 	t.Helper()
 
@@ -391,7 +399,7 @@ func TestClusterGenerate(t *testing.T) {
 
 	g := cluster.NewGenerator(c, newGeneratorOptions(), region, defaultNamespace, organizationID, projectID)
 
-	cluster, err := cluster.Generate(ctx, g, appclient, clusterRequestFixture(kubernetesVersion2))
+	cluster, err := cluster.Generate(ctx, g, appclient, clusterManagerFixture(), clusterRequestFixture(kubernetesVersion2))
 	require.NoError(t, err)
 
 	// Metadata is all correct...
@@ -440,7 +448,7 @@ func TestClusterUpgrade(t *testing.T) {
 	g := cluster.NewGenerator(c, newGeneratorOptions(), region, defaultNamespace, organizationID, projectID)
 	g = cluster.WithExisting(g, existingClusterFixture(t, kubernetesVersion1))
 
-	cluster, err := cluster.Generate(ctx, g, appclient, clusterRequestFixture(kubernetesVersion3))
+	cluster, err := cluster.Generate(ctx, g, appclient, clusterManagerFixture(), clusterRequestFixture(kubernetesVersion3))
 	require.NoError(t, err)
 
 	// Metadata is all correct...

--- a/pkg/server/handler/cluster/export_test.go
+++ b/pkg/server/handler/cluster/export_test.go
@@ -33,6 +33,6 @@ func GenerateApplicationBundleName(ctx context.Context, g *generator, appclient 
 	return g.generateApplicationBundleName(ctx, appclient, in)
 }
 
-func Generate(ctx context.Context, g *generator, appclient appBundleLister, request *openapi.KubernetesClusterWrite) (*unikornv1.KubernetesCluster, error) {
-	return g.generate(ctx, appclient, request)
+func Generate(ctx context.Context, g *generator, appclient appBundleLister, clusterManager *unikornv1.ClusterManager, request *openapi.KubernetesClusterWrite) (*unikornv1.KubernetesCluster, error) {
+	return g.generate(ctx, appclient, clusterManager, request)
 }

--- a/pkg/server/handler/clustermanager/client.go
+++ b/pkg/server/handler/clustermanager/client.go
@@ -268,7 +268,11 @@ func (c *Client) Delete(ctx context.Context, organizationID, projectID, clusterM
 		},
 	}
 
-	if err := c.client.Delete(ctx, controlPlane); err != nil {
+	options := &client.DeleteOptions{
+		PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
+	}
+
+	if err := c.client.Delete(ctx, controlPlane, options); err != nil {
 		if kerrors.IsNotFound(err) {
 			return errors.HTTPNotFound().WithError(err)
 		}


### PR DESCRIPTION
The region service uses owner references and blocking foreground deletion, so in the interests of consistency, move to that way of working so if and when we do replace it with something else it'll be a lot easier following the same script.